### PR TITLE
Push elements into array instead of concatenating strings

### DIFF
--- a/scripts/fix-opera.sh
+++ b/scripts/fix-opera.sh
@@ -33,11 +33,11 @@ readonly WIDEVINE_MANIFEST_NAME='manifest.json'
 OPERA_VERSIONS=()
 
 if [ -x "$(command -v opera)" ]; then
-  OPERA_VERSIONS+="opera"
+  OPERA_VERSIONS+=("opera")
 fi
 
 if [ -x "$(command -v opera-beta)" ]; then
-  OPERA_VERSIONS+="opera-beta"
+  OPERA_VERSIONS+=("opera-beta")
 fi
 
 for opera in ${OPERA_VERSIONS[@]}; do


### PR DESCRIPTION
Current logic is concatenating strings instead of pushing into an array, so it ends up doing `operaopera-beta` if both operas are installed

```
Doing operaopera-beta
```

then the path is incorrect and it fails to apply the fix when both opera and opera-beta are installed

```
./scripts/fix-opera.sh: línea 119: /resources/widevine_config.json: No existe el archivo o el directorio
```

(that means `the file or directory does not exist`, cause it fails to find the base `OPERA_DIR` path so it's an empty string)
