### PR TITLE
Download files only once, fix issue setting readonly vars

### DIFF
--- a/scripts/fix-opera.sh
+++ b/scripts/fix-opera.sh
@@ -40,59 +40,59 @@ if [ -x "$(command -v opera-beta)" ]; then
   OPERA_VERSIONS+=("opera-beta")
 fi
 
+#Getting download links
+printf 'Getting download links...\n'
+##ffmpeg
+readonly FFMPEG_URL_MAIN=$(wget -q4O - $FFMPEG_SRC_MAIN | grep browser_download_url | cut -d '"' -f 4 | grep linux-x64 | head -n 1)
+readonly FFMPEG_URL_ALT=$(wget -q4O - $FFMPEG_SRC_ALT | grep browser_download_url | cut -d '"' -f 4 | grep linux-x64 | head -n 1)
+[[ $(basename $FFMPEG_URL_ALT) < $(basename $FFMPEG_URL_MAIN) ]] && readonly FFMPEG_URL=$FFMPEG_URL_MAIN || readonly FFMPEG_URL=$FFMPEG_URL_ALT
+if [[ -z $FFMPEG_URL ]]; then
+  printf 'Failed to get ffmpeg download URL. Exiting...\n'
+  exit 1
+fi
+
+##Widevine
+if $FIX_WIDEVINE; then
+  readonly WIDEVINE_LATEST=`wget -q4O - $WIDEVINE_VERSIONS | tail -n1`
+  readonly WIDEVINE_URL="https://dl.google.com/widevine-cdm/$WIDEVINE_LATEST-linux-x64.zip"
+fi
+
+#Downloading files
+printf 'Downloading files...\n'
+mkdir -p "$TEMP_DIR/opera-fix"
+##ffmpeg
+wget -q4 --show-progress $FFMPEG_URL -O "$TEMP_DIR/opera-fix/ffmpeg.zip"
+if [ $? -ne 0 ]; then
+  printf 'Failed to download ffmpeg. Check your internet connection or try later\n'
+  exit 1
+fi
+##Widevine
+if $FIX_WIDEVINE;  then
+  wget -q4 --show-progress "$WIDEVINE_URL" -O "$TEMP_DIR/opera-fix/widevine.zip"
+  if [ $? -ne 0 ]; then
+    printf 'Failed to download Widevine CDM. Check your internet connection or try later\n'
+    exit 1
+  fi
+fi
+
+#Extracting files
+printf 'Extracting files...\n'
+##ffmpeg
+unzip -o "$TEMP_DIR/opera-fix/ffmpeg.zip" -d $TEMP_DIR/opera-fix > /dev/null
+##Widevine
+if $FIX_WIDEVINE; then
+  unzip -o "$TEMP_DIR/opera-fix/widevine.zip" -d $TEMP_DIR/opera-fix > /dev/null
+fi
+
 for opera in ${OPERA_VERSIONS[@]}; do
   echo "Doing $opera"
   EXECUTABLE=$(command -v "$opera")
 
-  readonly OPERA_DIR=$(dirname $(readlink -f $EXECUTABLE))
-  readonly OPERA_LIB_DIR="$OPERA_DIR/lib_extra"
-  readonly OPERA_WIDEVINE_DIR="$OPERA_LIB_DIR/WidevineCdm"
-  readonly OPERA_WIDEVINE_SO_DIR="$OPERA_WIDEVINE_DIR/_platform_specific/linux_x64"
-  readonly OPERA_WIDEVINE_CONFIG="$OPERA_DIR/resources/widevine_config.json"
-
-  #Getting download links
-  printf 'Getting download links...\n'
-  ##ffmpeg
-  readonly FFMPEG_URL_MAIN=$(wget -q4O - $FFMPEG_SRC_MAIN | grep browser_download_url | cut -d '"' -f 4 | grep linux-x64 | head -n 1)
-  readonly FFMPEG_URL_ALT=$(wget -q4O - $FFMPEG_SRC_ALT | grep browser_download_url | cut -d '"' -f 4 | grep linux-x64 | head -n 1)
-  [[ $(basename $FFMPEG_URL_ALT) < $(basename $FFMPEG_URL_MAIN) ]] && readonly FFMPEG_URL=$FFMPEG_URL_MAIN || readonly FFMPEG_URL=$FFMPEG_URL_ALT
-  if [[ -z $FFMPEG_URL ]]; then
-    printf 'Failed to get ffmpeg download URL. Exiting...\n'
-    exit 1
-  fi
-
-  ##Widevine
-  if $FIX_WIDEVINE; then
-    readonly WIDEVINE_LATEST=`wget -q4O - $WIDEVINE_VERSIONS | tail -n1`
-    readonly WIDEVINE_URL="https://dl.google.com/widevine-cdm/$WIDEVINE_LATEST-linux-x64.zip"
-  fi
-
-  #Downloading files
-  printf 'Downloading files...\n'
-  mkdir -p "$TEMP_DIR/$opera-fix"
-  ##ffmpeg
-  wget -q4 --show-progress $FFMPEG_URL -O "$TEMP_DIR/$opera-fix/ffmpeg.zip"
-  if [ $? -ne 0 ]; then
-    printf 'Failed to download ffmpeg. Check your internet connection or try later\n'
-    exit 1
-  fi
-  ##Widevine
-  if $FIX_WIDEVINE;  then
-    wget -q4 --show-progress "$WIDEVINE_URL" -O "$TEMP_DIR/$opera-fix/widevine.zip"
-    if [ $? -ne 0 ]; then
-      printf 'Failed to download Widevine CDM. Check your internet connection or try later\n'
-      exit 1
-    fi
-  fi
-
-  #Extracting files
-  printf 'Extracting files...\n'
-  ##ffmpeg
-  unzip -o "$TEMP_DIR/$opera-fix/ffmpeg.zip" -d $TEMP_DIR/$opera-fix > /dev/null
-  ##Widevine
-  if $FIX_WIDEVINE; then
-    unzip -o "$TEMP_DIR/$opera-fix/widevine.zip" -d $TEMP_DIR/$opera-fix > /dev/null
-  fi
+  OPERA_DIR=$(dirname $(readlink -f $EXECUTABLE))
+  OPERA_LIB_DIR="$OPERA_DIR/lib_extra"
+  OPERA_WIDEVINE_DIR="$OPERA_LIB_DIR/WidevineCdm"
+  OPERA_WIDEVINE_SO_DIR="$OPERA_WIDEVINE_DIR/_platform_specific/linux_x64"
+  OPERA_WIDEVINE_CONFIG="$OPERA_DIR/resources/widevine_config.json"
 
   #Removing old libraries and preparing directories
   printf 'Removing old libraries & making directories...\n'
@@ -108,18 +108,18 @@ for opera in ${OPERA_VERSIONS[@]}; do
   #Moving libraries to its place
   printf 'Moving libraries to their places...\n'
   ##ffmpeg
-  mv -f "$TEMP_DIR/$opera-fix/$FFMPEG_SO_NAME" "$OPERA_LIB_DIR"
+  cp -f "$TEMP_DIR/opera-fix/$FFMPEG_SO_NAME" "$OPERA_LIB_DIR"
   chmod 0644 "$OPERA_LIB_DIR/$FFMPEG_SO_NAME"
   ##Widevine
   if $FIX_WIDEVINE; then
-    mv -f "$TEMP_DIR/$opera-fix/$WIDEVINE_SO_NAME" "$OPERA_WIDEVINE_SO_DIR"
+    cp -f "$TEMP_DIR/opera-fix/$WIDEVINE_SO_NAME" "$OPERA_WIDEVINE_SO_DIR"
     chmod 0644 "$OPERA_WIDEVINE_SO_DIR/$WIDEVINE_SO_NAME"
-    mv -f "$TEMP_DIR/$opera-fix/$WIDEVINE_MANIFEST_NAME" "$OPERA_WIDEVINE_DIR"
+    cp -f "$TEMP_DIR/opera-fix/$WIDEVINE_MANIFEST_NAME" "$OPERA_WIDEVINE_DIR"
     chmod 0644 "$OPERA_WIDEVINE_DIR/$WIDEVINE_MANIFEST_NAME"
     printf "[\n      {\n         \"preload\": \"$OPERA_WIDEVINE_DIR\"\n      }\n]\n" > "$OPERA_WIDEVINE_CONFIG"
   fi
-
-  #Removing temporary files
-  printf 'Removing temporary files...\n'
-  rm -rf "$TEMP_DIR/$opera-fix"
 done
+
+#Removing temporary files
+printf 'Removing temporary files...\n'
+rm -rf "$TEMP_DIR/opera-fix"


### PR DESCRIPTION
This PR fixes 2 issues when having both opera and opera-beta installed:

- when iterating over the `operas` array, variables were `readonly` so setting the path for `opera-beta` was not really working
- files were getting downloaded twice (once for each opera)

now the files are downloaded before looping, so they are downloaded once in a fixed `/tmp/opera-fix` path
instead of moving the files I copy them so I don't have to re-download for each opera
I remove the temp dir after the loop