### PR TITLE
Fix for arch based systems

### DIFF
--- a/scripts/fix-opera.sh
+++ b/scripts/fix-opera.sh
@@ -20,8 +20,12 @@ if ! which wget > /dev/null; then
 	exit 1
 fi
 
+if which pacman > /dev/null; then
+	ARCH_SYSTEM=true
+fi
+
 #Config section
-readonly FIX_WIDEVINE=true
+readonly FIX_WIDEVINE=false
 readonly TEMP_DIR='/tmp'
 readonly FFMPEG_SRC_MAIN='https://api.github.com/repos/Ld-Hagen/nwjs-ffmpeg-prebuilt/releases'
 readonly FFMPEG_SRC_ALT='https://api.github.com/repos/Ld-Hagen/fix-opera-linux-ffmpeg-widevine/releases'
@@ -87,8 +91,11 @@ fi
 for opera in ${OPERA_VERSIONS[@]}; do
   echo "Doing $opera"
   EXECUTABLE=$(command -v "$opera")
-
-  OPERA_DIR=$(dirname $(readlink -f $EXECUTABLE))
+	if [[ $ARCH_SYSTEM -eq true ]]; then
+		OPERA_DIR="/usr/lib/$opera"
+	else
+		OPERA_DIR=$(dirname $(readlink -f $EXECUTABLE))
+	fi
   OPERA_LIB_DIR="$OPERA_DIR/lib_extra"
   OPERA_WIDEVINE_DIR="$OPERA_LIB_DIR/WidevineCdm"
   OPERA_WIDEVINE_SO_DIR="$OPERA_WIDEVINE_DIR/_platform_specific/linux_x64"

--- a/scripts/fix-opera.sh
+++ b/scripts/fix-opera.sh
@@ -25,7 +25,7 @@ if which pacman > /dev/null; then
 fi
 
 #Config section
-readonly FIX_WIDEVINE=false
+readonly FIX_WIDEVINE=true
 readonly TEMP_DIR='/tmp'
 readonly FFMPEG_SRC_MAIN='https://api.github.com/repos/Ld-Hagen/nwjs-ffmpeg-prebuilt/releases'
 readonly FFMPEG_SRC_ALT='https://api.github.com/repos/Ld-Hagen/fix-opera-linux-ffmpeg-widevine/releases'


### PR DESCRIPTION
On arch based system the /lib_extra directory is in a different path than on others. If you think about a better way than just hardcoding it in like this than you're more than welcome to do it differently. 

But this quick fix works.