### PR TITLE
fix(fix-opera.sh): rm ffmpeg.so in root path

### DIFF
--- a/scripts/fix-opera.sh
+++ b/scripts/fix-opera.sh
@@ -121,7 +121,6 @@ for opera in ${OPERA_VERSIONS[@]}; do
   #Moving libraries to its place
   printf 'Moving libraries to their places...\n'
   ##ffmpeg
-  cp -f "$TEMP_DIR/opera-fix/$FFMPEG_SO_NAME" "$OPERA_DIR"
   cp -f "$TEMP_DIR/opera-fix/$FFMPEG_SO_NAME" "$OPERA_LIB_DIR"
   chmod 0644 "$OPERA_LIB_DIR/$FFMPEG_SO_NAME"
   ##Widevine

--- a/scripts/fix-opera.sh
+++ b/scripts/fix-opera.sh
@@ -109,6 +109,7 @@ for opera in ${OPERA_VERSIONS[@]}; do
   #Removing old libraries and preparing directories
   printf 'Removing old libraries & making directories...\n'
   ##ffmpeg
+  rm -f "$OPERA_DIR/$FFMPEG_SO_NAME"
   rm -f "$OPERA_LIB_DIR/$FFMPEG_SO_NAME"
   mkdir -p "$OPERA_LIB_DIR"
   ##Widevine
@@ -120,6 +121,7 @@ for opera in ${OPERA_VERSIONS[@]}; do
   #Moving libraries to its place
   printf 'Moving libraries to their places...\n'
   ##ffmpeg
+  cp -f "$TEMP_DIR/opera-fix/$FFMPEG_SO_NAME" "$OPERA_DIR"
   cp -f "$TEMP_DIR/opera-fix/$FFMPEG_SO_NAME" "$OPERA_LIB_DIR"
   chmod 0644 "$OPERA_LIB_DIR/$FFMPEG_SO_NAME"
   ##Widevine


### PR DESCRIPTION
Hey @Ld-Hagen, first off, thank you for this script it truly saved me a headache on getting twitch to work on my opera.

However, I noticed that on one instance that I upgraded, I started to get the error 4000 again and for some reason, on the root of my opera install I had a `ffmpeg.so` file. I've extended your script to rm it so we use your file in `lib-extra` instead, and everything seems to be working fine.

Let me know if you're okay with this approach and I'll merge it in, if not, feel free to close.

Cheers!