### PR TITLE
Hardcode Widevine URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,17 @@
 
    **unzip** (Is needed for unpacking the downloaded file)
 
+   **bsdtar/libarchive** (Is needed for unpacking the widevine lib)
+
    **git** (Is needed for fetching this script)
 
    **jq** (Is needed for parsing JSON from github)
 
-	For Debian-based systems: `sudo apt install curl unzip git jq`
+	For Debian-based systems: `sudo apt install curl unzip libarchive-tools git jq`
 
-	For Arch-based systems: `sudo pacman -S curl unzip git jq`
+	For Arch-based systems: `sudo pacman -S curl unzip libarchive git jq`
 
-	For RedHat-based systems: `sudo dnf install curl unzip git jq`
+	For RedHat-based systems: `sudo dnf install curl unzip bsdtar git jq`
 	
 3. (*Optional*) **python3-dnf-plugin-post-transaction-actions** (Is needed for autoupdate in RedHat-based systems)
 	`dnf install python3-dnf-plugin-post-transaction-actions`

--- a/install.sh
+++ b/install.sh
@@ -14,6 +14,12 @@ if ! which unzip > /dev/null; then
 	exit 1
 fi
 
+if ! which bsdtar > /dev/null; then
+        printf '\033[1mlibarchive\033[0m package must be installed to run this script\n'
+        exit 1
+fi
+
+
 if ! which curl > /dev/null; then
 	printf '\033[1mcurl\033[0m package must be installed to run this script\n'
 	exit 1


### PR DESCRIPTION
This hopefully fixes #33. It hardcodes a link to the latest `.crx3` file that Google provides as they don't seem to provide a `.zip` anymore. This file is `bsdtar` packed, so we need that installed to unpack it. Please note that it will need to be updated anytime there's a new release. Mozilla do track this URL for Firefox, that's [here](https://github.com/mozilla-firefox/firefox/blob/main/toolkit/content/gmp-sources/widevinecdm.json#L30).

This script runs fine on my Fedora 42.