### PR TITLE
Block LD_PRELOAD

### DIFF
--- a/scripts/fix-opera.sh
+++ b/scripts/fix-opera.sh
@@ -124,6 +124,8 @@ for opera in ${OPERA_VERSIONS[@]}; do
   ##ffmpeg
   cp -f "$FIX_DIR/$FFMPEG_SO_NAME" "$OPERA_LIB_DIR"
   chmod 0644 "$OPERA_LIB_DIR/$FFMPEG_SO_NAME"
+  #block LD_PRELOAD breaking soname compability
+  chmod a-r "$OPERA_DIR/$FFMPEG_SO_NAME"
   ##Widevine
   if $FIX_WIDEVINE; then
     cp -f "$FIX_DIR/$WIDEVINE_SO_NAME" "$OPERA_WIDEVINE_SO_DIR"


### PR DESCRIPTION
opera has incorrect `LD_PRELOAD` for bundled `.so` whick blocks loading `.so` with same internal major soname.
This should be fixed at upstream, but there is a no plan for it.