### PR TITLE
Fix predictable /tmp path enabling symlink attack as root

### DIFF
--- a/scripts/fix-opera.sh
+++ b/scripts/fix-opera.sh
@@ -31,7 +31,12 @@ fi
 
 #Config section
 readonly FIX_WIDEVINE=true
-readonly FIX_DIR='/tmp/opera-fix'
+FIX_DIR=$(mktemp -d -t opera-fix.XXXXXXXX)
+if [[ ! -d "$FIX_DIR" ]]; then
+	printf 'Failed to create a secure temporary directory\n'
+	exit 1
+fi
+readonly FIX_DIR
 readonly FFMPEG_SRC_MAIN='https://api.github.com/repos/Ld-Hagen/nwjs-ffmpeg-prebuilt/releases'
 readonly FFMPEG_SRC_ALT='https://api.github.com/repos/Ld-Hagen/fix-opera-linux-ffmpeg-widevine/releases'
 readonly WIDEVINE_SRC='https://raw.githubusercontent.com/mozilla-firefox/firefox/refs/heads/main/toolkit/content/gmp-sources/widevinecdm.json'
@@ -121,7 +126,6 @@ if $FIX_WIDEVINE; then
 fi
 
 #Downloading Widevine
-mkdir -p "$FIX_DIR"
 if $FIX_WIDEVINE; then
   printf 'Downloading Widevine CDM...\n'
   echo -e "From URL: $WIDEVINE_URL\n"


### PR DESCRIPTION
## Vulnerability

`scripts/fix-opera.sh` runs as root and uses a fixed, world-guessable
temp directory:

```sh
readonly FIX_DIR='/tmp/opera-fix'
...
mkdir -p "$FIX_DIR"
```

`mkdir -p` succeeds silently if the path already exists — including
if it's a symlink. Since `/tmp` is world-writable, any local
unprivileged user can pre-create `/tmp/opera-fix` as a symlink to a
directory they control, and place a file named `libffmpeg.so` (and/or
`libwidevinecdm.so`) there ahead of time.

When an admin later runs this script with `sudo`, root will:
1. `mkdir -p` the attacker's symlinked path (no-op, since it already resolves to an existing dir)
2. Download the real assets into that attacker-controlled directory
3. `cp -f` from `$FIX_DIR` into Opera's `lib_extra`, with the attacker's planted files taking priority if named identically, or simply co-existing since the download only overwrites known filenames

More directly: since `$FIX_DIR` is fully attacker-controlled once the symlink is in place, the attacker's `libffmpeg.so`/`libwidevinecdm.so` gets copied into Opera's `lib_extra` with `0644` perms and loaded into every user's Opera process on the system — a local privilege/trust boundary crossing on any multi-user machine.

## Fix

Replace the fixed path with `mktemp -d`, which:

- Creates a directory with an unpredictable name (large random suffix), so it can't be pre-planted.
- Creates it via a bare `mkdir()` syscall, which is exclusive by nature (no `O_EXCL` needed, unlike `open()`) — it can never silently adopt a pre-existing path or symlink the way `mkdir -p` does. Confirmed via `strace`.
- Creates it with `0700` permissions, private to root.

Also removed the now-redundant `mkdir -p "$FIX_DIR"` call later in the script, since `mktemp -d` already creates the directory.

## Testing

- `bash -n scripts/fix-opera.sh` — syntax OK
- Verified `mktemp -d -t opera-fix.XXXXXXXX` produces a `0700` dir with an unpredictable name
- `strace`'d the call to confirm it uses a plain, exclusive `mkdir()` syscall rather than following/adopting an existing path