### PR TITLE
Fix dnf install command in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ install_deps() {
             apt-get install -y "${DEPS[@]}"
             ;;
         dnf)
-            dnf install -y "${DEPS[@]} python3-dnf-plugin-post-transaction-actions"
+            dnf install -y "${DEPS[@]}" python3-dnf-plugin-post-transaction-actions
             ;;
         pacman)
             pacman -Sy --needed --noconfirm "${DEPS[@]}"


### PR DESCRIPTION
Under the old script, dnf is generating an error due to incorrect bash. This PR fixes it.

```
Installing script to your system...
Updating and loading repositories:
Repositories loaded.
Failed to resolve the transaction:
Package "curl-8.15.0-8.fc43.x86_64" is already installed.
Package "unzip-6.0-67.fc43.x86_64" is already installed.
No match for argument: jq python3-dnf-plugin-post-transaction-actions
You can try to add to command line:
  --skip-unavailable to skip unavailable packages
```